### PR TITLE
RSS patch

### DIFF
--- a/FTLDriveContinued/GameData/FTLDriveContinued/Parts/FTL_RSSpatch.cfg
+++ b/FTLDriveContinued/GameData/FTLDriveContinued/Parts/FTL_RSSpatch.cfg
@@ -1,0 +1,7 @@
+@PART[advancedFTLdriveS?]:NEEDS[RealSolarSystem&!SSRSS]
+{
+    @MODULE[FTLDriveModule]
+    {
+        @maxGeneratorForce *= 3
+    }
+}


### PR DESCRIPTION
More power is needed to travel in the RSS scale system; x3 makes it so that you need around 100.000km altitude on earth to be able to use the 2500i version to go to other planets.