### PR TITLE
Fix resource consumption issue on jump execution so only ElectricCharge and StoredCharge are zeroed out

### DIFF
--- a/Source/FTLDriveModule.cs
+++ b/Source/FTLDriveModule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -1347,7 +1347,7 @@ namespace ScienceFoundry.FTL
             {
                 foreach (PartResource r in p.Resources)
                 {
-                    r.amount = 0;
+                    if (r.resourceName == "ElectricCharge") { r.amount = 0; }
                 }
             });
 
@@ -1360,7 +1360,7 @@ namespace ScienceFoundry.FTL
             {
                 foreach (PartResource r in p.Resources)
                 {
-                    r.amount = 0;
+                    if (r.resourceName == "ElectricCharge") { r.amount = 0; }
                 }
             });
         }

--- a/Source/FTLDriveModule.cs
+++ b/Source/FTLDriveModule.cs
@@ -1360,7 +1360,7 @@ namespace ScienceFoundry.FTL
             {
                 foreach (PartResource r in p.Resources)
                 {
-                    if (r.resourceName == "ElectricCharge") { r.amount = 0; }
+                    if (r.resourceName == "StoredCharge") { r.amount = 0; }
                 }
             });
         }


### PR DESCRIPTION
Fixed the non-EC resource consumption on jump execution. Now only EC will be drained, while other resources are left as-is.